### PR TITLE
Save ARP scan results to SD card (issue #247)

### DIFF
--- a/docs/hugo docs/content/latest/getting-started/sd-card.md
+++ b/docs/hugo docs/content/latest/getting-started/sd-card.md
@@ -25,6 +25,20 @@ When initialized, GhostESP creates the following directory structure:
 └── nfc/            # NFC card data (if enabled)
 ```
 
+### Scan results (`scans/`)
+
+When **Auto Save Scans** is enabled (default), text scan outputs are written under `/mnt/ghostesp/scans/` with auto-incrementing filenames:
+
+| Command | Filename pattern |
+|---------|------------------|
+| `scanarp` | `arp_scan_wifi_<N>.txt` (optional `.csv` with `--csv`) |
+| `etharp` | `arp_scan_eth_<N>.txt` (optional `.csv` with `--csv`) |
+| ARP poison host discovery | `arp_scan_eth_poison_<N>.txt` |
+
+Use `-s` to save even when auto-save is disabled. Saved files include interface, subnet, scanner IP, timestamp, and OUI vendor when available.
+
+Disable auto-save with `set auto_save_scans false` or from **Settings → Auto Save Scans** on display builds.
+
 ## Web Serial Interface
 
 For the easiest file management experience, use the **Web Serial Interface** at:

--- a/include/core/arp_scan_save.h
+++ b/include/core/arp_scan_save.h
@@ -1,0 +1,33 @@
+#ifndef ARP_SCAN_SAVE_H
+#define ARP_SCAN_SAVE_H
+
+#include "esp_err.h"
+#include "scans/wifi/arp_scan.h"
+#include <stddef.h>
+#include <stdbool.h>
+
+typedef enum {
+    ARP_SCAN_IFACE_WIFI = 0,
+    ARP_SCAN_IFACE_ETHERNET,
+    ARP_SCAN_IFACE_ETHERNET_POISON,
+} arp_scan_iface_t;
+
+typedef struct {
+    const char *subnet_prefix;
+    arp_scan_iface_t iface;
+    const char *scanner_ip;
+    const arp_host_t *hosts;
+    size_t host_count;
+    bool force_save;
+    bool write_csv;
+} arp_scan_save_input_t;
+
+esp_err_t arp_scan_save_results(const arp_scan_save_input_t *in, char *path_out, size_t path_out_len);
+
+void arp_scan_save_report_status(esp_err_t err, const char *path);
+
+const char *arp_scan_save_last_path(void);
+
+const char *arp_scan_save_prefix_for_iface(arp_scan_iface_t iface);
+
+#endif

--- a/include/core/scan_saver.h
+++ b/include/core/scan_saver.h
@@ -11,10 +11,12 @@ typedef struct {
     bool jit_mounted;
     bool display_suspended;
     uint16_t write_count;
+    char path[128];
 } scan_file_t;
 
-#define SCAN_FILE_INIT { NULL, false, false, 0 }
+#define SCAN_FILE_INIT { NULL, false, false, 0, { 0 } }
 
+esp_err_t scan_file_open_ex(scan_file_t *sf, const char *prefix, const char *extension, bool force_save);
 esp_err_t scan_file_open(scan_file_t *sf, const char *prefix, const char *extension);
 void scan_file_printf(scan_file_t *sf, const char *fmt, ...) __attribute__((format(printf, 2, 3)));
 void scan_file_close(scan_file_t *sf);

--- a/include/managers/wifi_manager.h
+++ b/include/managers/wifi_manager.h
@@ -5,6 +5,7 @@
 
 #include "esp_err.h"
 #include "esp_wifi_types.h"
+#include "scans/wifi/arp_scan.h"
 
 #ifndef DNS_SERVER_HANDLE_T_DEFINED
 typedef struct dns_server_handle *dns_server_handle_t;
@@ -240,6 +241,7 @@ bool scan_ip_udp_port_range(const char *target_ip, uint16_t start_port,
 
 // ARP scan functions (wrapper that delegates to arp_scan module)
 bool wifi_manager_arp_scan_subnet(void);
+bool wifi_manager_arp_scan_subnet_ex(const arp_scan_run_options_t *opts);
 
 extern const uint16_t COMMON_PORTS[];
 extern const size_t NUM_PORTS;

--- a/include/scans/ethernet/eth_arp_scan.h
+++ b/include/scans/ethernet/eth_arp_scan.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "sdkconfig.h"
+
+#ifdef CONFIG_WITH_ETHERNET
+
+#include "esp_err.h"
+#include "scans/wifi/arp_scan.h"
+#include "lwip/netif.h"
+#include <stdbool.h>
+#include <stddef.h>
+
+#define ETH_ARP_SCAN_START_HOST 1
+#define ETH_ARP_SCAN_END_HOST   254
+
+bool eth_arp_build_subnet_prefix(uint32_t ip_addr, uint32_t netmask_addr,
+                                 char *prefix, size_t prefix_len);
+
+typedef struct {
+    struct netif *lwip_netif;
+    const char *subnet_prefix;
+    arp_host_t *hosts;
+    size_t max_hosts;
+    size_t found_count;
+    volatile bool *cancel;
+    int *progress_current;
+    int progress_total;
+} eth_arp_scan_params_t;
+
+esp_err_t eth_arp_scan_subnet_common(eth_arp_scan_params_t *params);
+
+#endif

--- a/include/scans/wifi/arp_scan.h
+++ b/include/scans/wifi/arp_scan.h
@@ -49,11 +49,24 @@ arp_scanner_ctx_t *arp_scanner_init(void);
 void arp_scanner_cleanup(arp_scanner_ctx_t *ctx);
 
 /**
+ * @brief Scan run options for ARP subnet scan
+ */
+typedef struct {
+    bool force_save;
+    bool write_csv;
+} arp_scan_run_options_t;
+
+/**
  * @brief Scan subnet for active hosts using ARP
  * 
  * @return true on success, false on failure
  */
 bool arp_scan_subnet(void);
+
+/**
+ * @brief Scan subnet with optional save flags
+ */
+bool arp_scan_subnet_ex(const arp_scan_run_options_t *opts);
 
 /**
  * @brief Print ARP scan results

--- a/main/attacks/ethernet/eth_arp_poison.c
+++ b/main/attacks/ethernet/eth_arp_poison.c
@@ -16,7 +16,9 @@
 
 #include "attacks/ethernet/eth_arp_poison.h"
 #include "managers/ethernet_manager.h"
+#include "core/arp_scan_save.h"
 #include "core/glog.h"
+#include "scans/wifi/arp_scan.h"
 #include "core/esp_comm_manager.h"
 #include "esp_netif.h"
 #include "lwip/netif.h"
@@ -854,6 +856,28 @@ esp_err_t eth_arp_poison_start(void)
     }
 
     glog("[ARP Poison] Found %d hosts\n", s_host_count);
+
+    if (s_host_count > 0) {
+        arp_host_t save_hosts[MAX_HOSTS];
+        for (int i = 0; i < s_host_count; i++) {
+            ip4addr_ntoa_r(&s_hosts[i].ip, save_hosts[i].ip, sizeof(save_hosts[i].ip));
+            memcpy(save_hosts[i].mac, s_hosts[i].mac, 6);
+            save_hosts[i].is_active = true;
+        }
+
+        char saved_path[128];
+        arp_scan_save_input_t save_in = {
+            .subnet_prefix = subnet_prefix,
+            .iface = ARP_SCAN_IFACE_ETHERNET_POISON,
+            .scanner_ip = our_ip_str,
+            .hosts = save_hosts,
+            .host_count = (size_t)s_host_count,
+            .force_save = false,
+            .write_csv = false,
+        };
+        esp_err_t save_err = arp_scan_save_results(&save_in, saved_path, sizeof(saved_path));
+        arp_scan_save_report_status(save_err, saved_path[0] ? saved_path : NULL);
+    }
 
     xTaskCreate(arp_poison_task, "arp_poison", 2048, NULL, 5, &s_poison_task);
     xTaskCreate(dns_proxy_task,  "dns_proxy",  4096, NULL, 6, &s_dns_task);

--- a/main/core/arp_scan_save.c
+++ b/main/core/arp_scan_save.c
@@ -1,0 +1,155 @@
+#include "core/arp_scan_save.h"
+#include "core/scan_saver.h"
+#include "core/ouis.h"
+#include "core/utils.h"
+#include "core/glog.h"
+#include "managers/settings_manager.h"
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
+static char s_last_path[128];
+
+static const char *iface_label(arp_scan_iface_t iface) {
+    switch (iface) {
+    case ARP_SCAN_IFACE_WIFI:
+        return "wifi";
+    case ARP_SCAN_IFACE_ETHERNET:
+        return "ethernet";
+    case ARP_SCAN_IFACE_ETHERNET_POISON:
+        return "ethernet_poison";
+    default:
+        return "unknown";
+    }
+}
+
+const char *arp_scan_save_prefix_for_iface(arp_scan_iface_t iface) {
+    switch (iface) {
+    case ARP_SCAN_IFACE_WIFI:
+        return "arp_scan_wifi";
+    case ARP_SCAN_IFACE_ETHERNET:
+        return "arp_scan_eth";
+    case ARP_SCAN_IFACE_ETHERNET_POISON:
+        return "arp_scan_eth_poison";
+    default:
+        return "arp_scan";
+    }
+}
+
+const char *arp_scan_save_last_path(void) {
+    return s_last_path;
+}
+
+void arp_scan_save_report_status(esp_err_t err, const char *path) {
+    if (err == ESP_OK && path && path[0]) {
+        glog("Scan saved to %s\n", path);
+        return;
+    }
+    if (err == ESP_ERR_NOT_SUPPORTED) {
+        glog("Scan not saved (auto_save_scans disabled; use -s to force save)\n");
+        return;
+    }
+    if (err == ESP_ERR_NOT_FOUND) {
+        glog("Scan not saved (SD card not mounted)\n");
+        return;
+    }
+    glog("Scan not saved (write failed)\n");
+}
+
+static void write_timestamp(scan_file_t *sf) {
+    time_t now = time(NULL);
+    struct tm tm_info;
+    if (localtime_r(&now, &tm_info) != NULL) {
+        char ts[32];
+        strftime(ts, sizeof(ts), "%Y-%m-%dT%H:%M:%S", &tm_info);
+        scan_file_printf(sf, "Timestamp: %s\n", ts);
+    }
+}
+
+static void write_host_lines_txt(scan_file_t *sf, const arp_host_t *hosts, size_t host_count) {
+    for (size_t i = 0; i < host_count; i++) {
+        char mac_str[18];
+        format_mac_address(hosts[i].mac, mac_str, sizeof(mac_str), true);
+
+        char vendor[64] = {0};
+        if (!ouis_lookup_vendor(mac_str, vendor, sizeof(vendor))) {
+            vendor[0] = '\0';
+        }
+
+        if (vendor[0]) {
+            scan_file_printf(sf, "%2zu. %s [%s] (Vendor: %s)\n", i + 1, hosts[i].ip, mac_str, vendor);
+        } else {
+            scan_file_printf(sf, "%2zu. %s [%s]\n", i + 1, hosts[i].ip, mac_str);
+        }
+    }
+}
+
+static esp_err_t write_csv_file(const char *prefix, bool force_save,
+                                const arp_host_t *hosts, size_t host_count) {
+    scan_file_t sf = SCAN_FILE_INIT;
+    esp_err_t err = scan_file_open_ex(&sf, prefix, "csv", force_save);
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    scan_file_printf(&sf, "ip,mac,vendor\n");
+    for (size_t i = 0; i < host_count; i++) {
+        char mac_str[18];
+        format_mac_address(hosts[i].mac, mac_str, sizeof(mac_str), true);
+        char vendor[64] = {0};
+        ouis_lookup_vendor(mac_str, vendor, sizeof(vendor));
+        scan_file_printf(&sf, "%s,%s,%s\n", hosts[i].ip, mac_str, vendor);
+    }
+
+    scan_file_close(&sf);
+    return ESP_OK;
+}
+
+esp_err_t arp_scan_save_results(const arp_scan_save_input_t *in, char *path_out, size_t path_out_len) {
+    if (!in || !in->subnet_prefix) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    s_last_path[0] = '\0';
+
+    if (!in->force_save && !settings_get_auto_save_scans(&G_Settings)) {
+        return ESP_ERR_NOT_SUPPORTED;
+    }
+
+    const char *prefix = arp_scan_save_prefix_for_iface(in->iface);
+    scan_file_t sf = SCAN_FILE_INIT;
+    esp_err_t err = scan_file_open_ex(&sf, prefix, "txt", in->force_save);
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    char subnet_line[32];
+    snprintf(subnet_line, sizeof(subnet_line), "%s0/24", in->subnet_prefix);
+    scan_file_printf(&sf, "--- ARP Scan Results (%zu hosts) ---\n", in->host_count);
+    scan_file_printf(&sf, "Interface: %s\n", iface_label(in->iface));
+    scan_file_printf(&sf, "Subnet: %s\n", subnet_line);
+    if (in->scanner_ip && in->scanner_ip[0]) {
+        scan_file_printf(&sf, "Scanner: %s\n", in->scanner_ip);
+    }
+    write_timestamp(&sf);
+    scan_file_printf(&sf, "\n");
+
+    if (in->hosts && in->host_count > 0) {
+        write_host_lines_txt(&sf, in->hosts, in->host_count);
+    }
+
+    if (sf.path[0]) {
+        strlcpy(s_last_path, sf.path, sizeof(s_last_path));
+        if (path_out && path_out_len > 0) {
+            strlcpy(path_out, sf.path, path_out_len);
+        }
+    }
+
+    scan_file_close(&sf);
+
+    if (in->write_csv && in->hosts && in->host_count > 0) {
+        write_csv_file(prefix, in->force_save, in->hosts, in->host_count);
+    }
+
+    return ESP_OK;
+}

--- a/main/core/commandline.c
+++ b/main/core/commandline.c
@@ -43,6 +43,9 @@
 #endif
 #ifdef CONFIG_WITH_ETHERNET
 #include "managers/ethernet_manager.h"
+#include "core/arp_scan_save.h"
+#include "scans/wifi/arp_scan.h"
+#include "scans/ethernet/eth_arp_scan.h"
 #include "managers/ethernet/eth_comm_handler.h"
 #include "managers/ethernet/eth_fingerprint.h"
 #include "managers/ethernet/eth_utils.h"
@@ -2039,6 +2042,16 @@ void handle_eth_info_cmd(int argc, char **argv) {
 }
 
 void handle_eth_arp_cmd(int argc, char **argv) {
+    bool force_save = false;
+    bool write_csv = false;
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "-s") == 0) {
+            force_save = true;
+        } else if (strcmp(argv[i], "--csv") == 0) {
+            write_csv = true;
+        }
+    }
+
     // Ensure Ethernet interface is initialized
     if (!ensure_eth_interface_up()) {
         return;
@@ -2078,88 +2091,66 @@ void handle_eth_arp_cmd(int argc, char **argv) {
 
     // Calculate subnet prefix (e.g., "192.168.1.")
     char subnet_prefix[16];
-    uint32_t ip = ip_info.ip.addr;
-    uint32_t netmask = ip_info.netmask.addr;
-    uint32_t network = ip & netmask;
-    
-    snprintf(subnet_prefix, sizeof(subnet_prefix), "%d.%d.%d.",
-             (int)((network >> 0) & 0xFF),
-             (int)((network >> 8) & 0xFF),
-             (int)((network >> 16) & 0xFF));
+    if (!eth_arp_build_subnet_prefix(ip_info.ip.addr, ip_info.netmask.addr,
+                                     subnet_prefix, sizeof(subnet_prefix))) {
+        glog("Failed to build subnet prefix\n");
+        return;
+    }
 
     g_eth_scan_cancel = false;
     glog("Starting ARP scan on Ethernet network %s0/24\n", subnet_prefix);
     glog("Scanning network using ARP requests...\n");
 
-    const int START_HOST = 1;
-    const int END_HOST = 254;
-    const int batch_size = 10;
-    int num_found = 0;
+    arp_host_t hosts[254];
+    int progress_current = 0;
+    eth_arp_scan_params_t scan_params = {
+        .lwip_netif = lwip_netif,
+        .subnet_prefix = subnet_prefix,
+        .hosts = hosts,
+        .max_hosts = sizeof(hosts) / sizeof(hosts[0]),
+        .found_count = 0,
+        .cancel = &g_eth_scan_cancel,
+        .progress_current = &progress_current,
+        .progress_total = ETH_ARP_SCAN_END_HOST - ETH_ARP_SCAN_START_HOST + 1,
+    };
 
-    // Scan the subnet in batches
-    for (int batch_start = START_HOST; batch_start <= END_HOST && !g_eth_scan_cancel; batch_start += batch_size) {
-        int batch_end = (batch_start + batch_size - 1 > END_HOST) ? END_HOST : batch_start + batch_size - 1;
-        
-        // Send batch of ARP requests
-        for (int host = batch_start; host <= batch_end && !g_eth_scan_cancel; host++) {
-            char current_ip[26];
-            snprintf(current_ip, sizeof(current_ip), "%s%d", subnet_prefix, host);
-            
-            // Parse IP address
-            ip4_addr_t target_addr;
-            if (ip4addr_aton(current_ip, &target_addr)) {
-                // Send ARP request using lwIP
-                etharp_request(lwip_netif, &target_addr);
-            }
-            vTaskDelay(pdMS_TO_TICKS(10)); // Small delay between requests
-        }
-        if (g_eth_scan_cancel) break;
-        
-        // Wait for responses to arrive
-        for (int i = 0; i < 5 && !g_eth_scan_cancel; i++) {
-            vTaskDelay(pdMS_TO_TICKS(50));
-        }
-        
-        // Check ARP table for this batch
-        for (int host = batch_start; host <= batch_end && !g_eth_scan_cancel; host++) {
-            char current_ip[26];
-            snprintf(current_ip, sizeof(current_ip), "%s%d", subnet_prefix, host);
-            
-            // Parse IP address
-            ip4_addr_t target_addr;
-            if (!ip4addr_aton(current_ip, &target_addr)) {
-                continue;
-            }
-            
-            // Search ARP table
-            struct eth_addr *eth_ret = NULL;
-            const ip4_addr_t *ip_ret = NULL;
-            s8_t arp_idx = etharp_find_addr(lwip_netif, &target_addr, &eth_ret, &ip_ret);
-            
-            if (arp_idx >= 0 && eth_ret) {
-                num_found++;
-                glog("  %-15s %02x:%02x:%02x:%02x:%02x:%02x\n",
-                     current_ip,
-                     eth_ret->addr[0], eth_ret->addr[1], eth_ret->addr[2],
-                     eth_ret->addr[3], eth_ret->addr[4], eth_ret->addr[5]);
-            }
-        }
-        
-        // Progress update
-        if (batch_end % 50 == 0 || batch_end == END_HOST) {
-            glog("Progress: Scanned %d/%d hosts, found %d active hosts\n", 
-                 batch_end - START_HOST + 1, END_HOST - START_HOST + 1, num_found);
-        }
+    eth_arp_scan_subnet_common(&scan_params);
+
+    for (size_t i = 0; i < scan_params.found_count; i++) {
+        glog("  %-15s %02x:%02x:%02x:%02x:%02x:%02x\n",
+             hosts[i].ip,
+             hosts[i].mac[0], hosts[i].mac[1], hosts[i].mac[2],
+             hosts[i].mac[3], hosts[i].mac[4], hosts[i].mac[5]);
     }
+
+    glog("Progress: Scanned %d/%d hosts, found %zu active hosts\n",
+         progress_current, scan_params.progress_total, scan_params.found_count);
 
     glog("\n=== ARP Scan Summary ===\n");
     glog("Network: %s0/24\n", subnet_prefix);
-    glog("Hosts scanned: %d (1-254)\n", END_HOST - START_HOST + 1);
-    glog("Active hosts found: %d\n", num_found);
-    if (num_found > 0) {
-        glog("Success rate: %.1f%%\n", (float)num_found / (END_HOST - START_HOST + 1) * 100.0f);
+    glog("Hosts scanned: %d (1-254)\n", scan_params.progress_total);
+    glog("Active hosts found: %zu\n", scan_params.found_count);
+    if (scan_params.found_count > 0) {
+        glog("Success rate: %.1f%%\n",
+             (float)scan_params.found_count / scan_params.progress_total * 100.0f);
     }
     glog("=======================\n");
+
+    char scanner_ip[16];
+    esp_ip4addr_ntoa(&ip_info.ip, scanner_ip, sizeof(scanner_ip));
+
+    char saved_path[128];
+    arp_scan_save_input_t save_in = {
+        .subnet_prefix = subnet_prefix,
+        .iface = ARP_SCAN_IFACE_ETHERNET,
+        .scanner_ip = scanner_ip,
+        .hosts = hosts,
+        .host_count = scan_params.found_count,
+        .force_save = force_save,
+        .write_csv = write_csv,
+    };
+    esp_err_t save_err = arp_scan_save_results(&save_in, saved_path, sizeof(saved_path));
+    arp_scan_save_report_status(save_err, saved_path[0] ? saved_path : NULL);
 }
 
 void handle_eth_ports_cmd(int argc, char **argv) {
@@ -3959,8 +3950,17 @@ void handle_scan_ports(int argc, char **argv) {
 }
 
 void handle_scan_arp(int argc, char **argv) {
+    arp_scan_run_options_t opts = {0};
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "-s") == 0) {
+            opts.force_save = true;
+        } else if (strcmp(argv[i], "--csv") == 0) {
+            opts.write_csv = true;
+        }
+    }
+
     glog("Starting ARP scan on local network...\n");
-    wifi_manager_arp_scan_subnet();
+    wifi_manager_arp_scan_subnet_ex(&opts);
     status_display_show_status("ARP Scan");
 }
 
@@ -4421,7 +4421,8 @@ void handle_help(int argc, char **argv) {
         glog("        (no range) : Scan common ports (default)\n\n");
         glog("scanarp\n");
         glog("    Description: Perform ARP scan on local network to discover active hosts\n");
-        glog("    Usage: scanarp\n\n");
+        glog("    Usage: scanarp [-s] [--csv]\n");
+        glog("    Options: -s force save to SD; --csv also write CSV file\n\n");
         glog("settings\n");
         glog("    Description: Manage NVS stored settings via command line\n");
         glog("    Usage: settings <command> [arguments]\n");
@@ -4616,7 +4617,8 @@ void handle_help(int argc, char **argv) {
         printf("    Discovers: Apple devices, Chromecasts, printers, Windows PCs, routers, smart TVs\n\n");
         printf("etharp\n");
         printf("    Description: Perform ARP scan on local Ethernet network.\n");
-        printf("    Usage: etharp\n");
+        printf("    Usage: etharp [-s] [--csv]\n");
+        printf("    Options: -s force save to SD; --csv also write CSV file\n");
         printf("    Scans: Local subnet (1-254) to discover active hosts\n\n");
         printf("ethports\n");
         printf("    Description: Scan TCP ports on a target IP address.\n");

--- a/main/core/scan_saver.c
+++ b/main/core/scan_saver.c
@@ -10,19 +10,15 @@
 #define FLUSH_INTERVAL 16
 
 static bool try_jit_mount(scan_file_t *sf) {
-#ifdef CONFIG_BUILD_CONFIG_TEMPLATE
-    if (strcmp(CONFIG_BUILD_CONFIG_TEMPLATE, "somethingsomething") == 0) {
-        bool disp_suspended = false;
-        if (sd_card_mount_for_flush(&disp_suspended) == ESP_OK) {
-            sf->jit_mounted = true;
-            sf->display_suspended = disp_suspended;
-            return true;
-        }
-        if (disp_suspended) sd_card_unmount_after_flush(disp_suspended);
+    bool disp_suspended = false;
+    if (sd_card_mount_for_flush(&disp_suspended) == ESP_OK) {
+        sf->jit_mounted = true;
+        sf->display_suspended = disp_suspended;
+        return true;
     }
-#else
-    (void)sf;
-#endif
+    if (disp_suspended) {
+        sd_card_unmount_after_flush(disp_suspended);
+    }
     return false;
 }
 
@@ -33,9 +29,9 @@ static void ensure_scans_dir(void) {
     }
 }
 
-esp_err_t scan_file_open(scan_file_t *sf, const char *prefix, const char *extension) {
+esp_err_t scan_file_open_ex(scan_file_t *sf, const char *prefix, const char *extension, bool force_save) {
     if (!sf || !prefix || !extension) return ESP_ERR_INVALID_ARG;
-    if (!settings_get_auto_save_scans(&G_Settings)) return ESP_ERR_NOT_SUPPORTED;
+    if (!force_save && !settings_get_auto_save_scans(&G_Settings)) return ESP_ERR_NOT_SUPPORTED;
 
     if (sf->fp) {
         fclose(sf->fp);
@@ -46,6 +42,7 @@ esp_err_t scan_file_open(scan_file_t *sf, const char *prefix, const char *extens
     sf->jit_mounted = false;
     sf->display_suspended = false;
     sf->write_count = 0;
+    sf->path[0] = '\0';
 
     if (!sd_card_manager.is_initialized) {
         if (!try_jit_mount(sf)) return ESP_ERR_NOT_FOUND;
@@ -56,11 +53,11 @@ esp_err_t scan_file_open(scan_file_t *sf, const char *prefix, const char *extens
     int idx = get_next_file_index(SCANS_DIR, prefix, extension);
     if (idx < 0) idx = 0;
 
-    char path[128];
-    snprintf(path, sizeof(path), "%s/%s_%d.%s", SCANS_DIR, prefix, idx, extension);
+    snprintf(sf->path, sizeof(sf->path), "%s/%s_%d.%s", SCANS_DIR, prefix, idx, extension);
 
-    sf->fp = fopen(path, "w");
+    sf->fp = fopen(sf->path, "w");
     if (!sf->fp) {
+        sf->path[0] = '\0';
         if (sf->jit_mounted) {
             sd_card_unmount_after_flush(sf->display_suspended);
             sf->jit_mounted = false;
@@ -68,8 +65,12 @@ esp_err_t scan_file_open(scan_file_t *sf, const char *prefix, const char *extens
         return ESP_FAIL;
     }
 
-    printf("Scan file opened: %s\n", path);
+    printf("Scan file opened: %s\n", sf->path);
     return ESP_OK;
+}
+
+esp_err_t scan_file_open(scan_file_t *sf, const char *prefix, const char *extension) {
+    return scan_file_open_ex(sf, prefix, extension, false);
 }
 
 void scan_file_printf(scan_file_t *sf, const char *fmt, ...) {

--- a/main/managers/ethernet/eth_scan_async.c
+++ b/main/managers/ethernet/eth_scan_async.c
@@ -4,6 +4,9 @@
 
 #include "managers/ethernet/eth_scan_async.h"
 #include "managers/ethernet_manager.h"
+#include "core/arp_scan_save.h"
+#include "scans/wifi/arp_scan.h"
+#include "scans/ethernet/eth_arp_scan.h"
 #include "core/glog.h"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
@@ -22,7 +25,6 @@
 #include <fcntl.h>
 
 // esp_netif_get_netif_impl is an internal ESP-IDF function not in public headers.
-// Forward-declare it the same way eth_arp_poison.c does at its line 43.
 void *esp_netif_get_netif_impl(esp_netif_t *esp_netif);
 
 static const char *TAG = "EthScanAsync";
@@ -61,14 +63,11 @@ static const char *port_to_service(uint16_t port) {
     }
 }
 
-// ---------------------------------------------------------------------------
-// ARP scan task
-// Mirrors handle_eth_arp_cmd: sends ARP requests in batches of 10 across the
-// local /24 subnet derived from the interface IP & netmask, then reads the
-// lwIP ARP table and stores hits in s_results.arp_hosts[].
-// ---------------------------------------------------------------------------
 static void arp_scan_task(void *arg) {
     ESP_LOGI(TAG, "ARP scan task started");
+
+    char subnet_prefix[16] = {0};
+    char scanner_ip[16] = {0};
 
     if (!ethernet_manager_is_connected()) {
         ESP_LOGW(TAG, "Ethernet not connected, aborting ARP scan");
@@ -82,6 +81,8 @@ static void arp_scan_task(void *arg) {
             goto done;
         }
 
+        esp_ip4addr_ntoa(&ip_info.ip, scanner_ip, sizeof(scanner_ip));
+
         esp_netif_t *eth_netif = ethernet_manager_get_netif();
         if (eth_netif == NULL) {
             ESP_LOGW(TAG, "No netif, aborting ARP scan");
@@ -94,83 +95,65 @@ static void arp_scan_task(void *arg) {
             goto done;
         }
 
-        // Build subnet prefix exactly as commandline.c does: use network = ip & netmask
-        // The lwIP addresses are stored in little-endian byte order (addr byte 0 = octet 0).
-        uint32_t ip       = ip_info.ip.addr;
-        uint32_t netmask  = ip_info.netmask.addr;
-        uint32_t network  = ip & netmask;
-
-        char subnet_prefix[16];
-        snprintf(subnet_prefix, sizeof(subnet_prefix), "%d.%d.%d.",
-                 (int)((network >>  0) & 0xFF),
-                 (int)((network >>  8) & 0xFF),
-                 (int)((network >> 16) & 0xFF));
+        if (!eth_arp_build_subnet_prefix(ip_info.ip.addr, ip_info.netmask.addr,
+                                         subnet_prefix, sizeof(subnet_prefix))) {
+            ESP_LOGW(TAG, "Failed to build subnet prefix");
+            goto done;
+        }
 
         ESP_LOGI(TAG, "ARP scan: %s0/24", subnet_prefix);
 
-        const int START_HOST = 1;
-        const int END_HOST   = 254;
-        const int batch_size = 10;
+        arp_host_t hosts[64];
+        int progress_current = 0;
+        eth_arp_scan_params_t scan_params = {
+            .lwip_netif = lwip_netif,
+            .subnet_prefix = subnet_prefix,
+            .hosts = hosts,
+            .max_hosts = sizeof(hosts) / sizeof(hosts[0]),
+            .found_count = 0,
+            .cancel = &s_cancelled,
+            .progress_current = &progress_current,
+            .progress_total = ETH_ARP_SCAN_END_HOST - ETH_ARP_SCAN_START_HOST + 1,
+        };
 
-        s_results.progress_total   = END_HOST - START_HOST + 1;
-        s_results.progress_current = 0;
+        s_results.progress_total = scan_params.progress_total;
+        eth_arp_scan_subnet_common(&scan_params);
 
-        for (int batch_start = START_HOST;
-             batch_start <= END_HOST && !s_cancelled;
-             batch_start += batch_size) {
-
-            int batch_end = batch_start + batch_size - 1;
-            if (batch_end > END_HOST) batch_end = END_HOST;
-
-            // Send ARP requests for this batch
-            for (int host = batch_start; host <= batch_end && !s_cancelled; host++) {
-                char current_ip[26];
-                snprintf(current_ip, sizeof(current_ip), "%s%d", subnet_prefix, host);
-
-                ip4_addr_t target_addr;
-                if (ip4addr_aton(current_ip, &target_addr)) {
-                    etharp_request(lwip_netif, &target_addr);
-                }
-                vTaskDelay(pdMS_TO_TICKS(10));
-            }
-
-            if (s_cancelled) break;
-
-            // Wait for ARP replies (5 × 50 ms = 250 ms)
-            for (int i = 0; i < 5 && !s_cancelled; i++) {
-                vTaskDelay(pdMS_TO_TICKS(50));
-            }
-
-            // Check ARP table for each host in the batch
-            for (int host = batch_start; host <= batch_end && !s_cancelled; host++) {
-                char current_ip[26];
-                snprintf(current_ip, sizeof(current_ip), "%s%d", subnet_prefix, host);
-
-                ip4_addr_t target_addr;
-                if (!ip4addr_aton(current_ip, &target_addr)) {
-                    continue;
-                }
-
-                struct eth_addr    *eth_ret = NULL;
-                const ip4_addr_t   *ip_ret  = NULL;
-                s8_t arp_idx = etharp_find_addr(lwip_netif, &target_addr, &eth_ret, &ip_ret);
-
-                if (arp_idx >= 0 && eth_ret) {
-                    if (s_results.arp_count < 64) {
-                        eth_arp_result_t *r = &s_results.arp_hosts[s_results.arp_count];
-                        strlcpy(r->ip_str, current_ip, sizeof(r->ip_str));
-                        memcpy(r->mac, eth_ret->addr, 6);
-                        r->hostname[0] = '\0'; // hostname resolution not attempted
-                        s_results.arp_count++;
-                    }
-                }
-
-                s_results.progress_current = host - START_HOST + 1;
-            }
+        s_results.arp_count = (int)scan_params.found_count;
+        s_results.progress_current = progress_current;
+        for (int i = 0; i < s_results.arp_count && i < 64; i++) {
+            eth_arp_result_t *r = &s_results.arp_hosts[i];
+            strlcpy(r->ip_str, hosts[i].ip, sizeof(r->ip_str));
+            memcpy(r->mac, hosts[i].mac, 6);
+            r->hostname[0] = '\0';
         }
     }
 
 done:
+    if (subnet_prefix[0] && !s_cancelled) {
+        arp_host_t hosts[64];
+        size_t count = 0;
+        for (int i = 0; i < s_results.arp_count && i < 64; i++) {
+            strlcpy(hosts[i].ip, s_results.arp_hosts[i].ip_str, sizeof(hosts[i].ip));
+            memcpy(hosts[i].mac, s_results.arp_hosts[i].mac, 6);
+            hosts[i].is_active = true;
+            count++;
+        }
+
+        char saved_path[128];
+        arp_scan_save_input_t save_in = {
+            .subnet_prefix = subnet_prefix,
+            .iface = ARP_SCAN_IFACE_ETHERNET,
+            .scanner_ip = scanner_ip[0] ? scanner_ip : NULL,
+            .hosts = count > 0 ? hosts : NULL,
+            .host_count = count,
+            .force_save = false,
+            .write_csv = false,
+        };
+        esp_err_t save_err = arp_scan_save_results(&save_in, saved_path, sizeof(saved_path));
+        arp_scan_save_report_status(save_err, saved_path[0] ? saved_path : NULL);
+    }
+
     s_results.done = true;
     s_done         = true;
     s_running      = false;
@@ -178,7 +161,6 @@ done:
     ESP_LOGI(TAG, "ARP scan done: %d hosts found", s_results.arp_count);
     vTaskDelete(NULL);
 }
-
 // ---------------------------------------------------------------------------
 // Port scan task
 // Mirrors handle_eth_ports_cmd:

--- a/main/managers/views/ethernet_screen.c
+++ b/main/managers/views/ethernet_screen.c
@@ -28,6 +28,7 @@
 // Local mode: device has physical ethernet hardware
 #ifdef CONFIG_WITH_ETHERNET
 #define ETH_HAS_LOCAL 1
+#include "core/arp_scan_save.h"
 #include "managers/ethernet_manager.h"
 #include "managers/ethernet/eth_scan_async.h"
 #include "managers/ethernet/eth_fingerprint.h"
@@ -1042,6 +1043,16 @@ static void build_arp_list(void) {
     }
     if (s_scan.arp_count == 0)
         options_view_add_item(s_action_ov, "No hosts found", NULL, NULL);
+#ifdef ETH_HAS_LOCAL
+    {
+        const char *saved = arp_scan_save_last_path();
+        if (saved && saved[0]) {
+            char save_label[96];
+            snprintf(save_label, sizeof(save_label), "Saved: %s", saved);
+            options_view_add_item(s_action_ov, save_label, NULL, NULL);
+        }
+    }
+#endif
     options_view_add_back_row(s_action_ov, on_back_to_dashboard, NULL);
     int sel = (s_selected_arp_host >= 0 && s_selected_arp_host < s_scan.arp_count)
               ? s_selected_arp_host : 0;

--- a/main/managers/wifi_manager.c
+++ b/main/managers/wifi_manager.c
@@ -2546,6 +2546,10 @@ bool wifi_manager_arp_scan_subnet(void) {
     return arp_scan_subnet();
 }
 
+bool wifi_manager_arp_scan_subnet_ex(const arp_scan_run_options_t *opts) {
+    return arp_scan_subnet_ex(opts);
+}
+
 // Wrapper function that delegates to port_scan module
 void scan_ports_on_host(const char *target_ip, host_result_t *result) {
     // Cast host_result_t to port_scan_result_t since they have the same structure

--- a/main/scans/ethernet/eth_arp_scan.c
+++ b/main/scans/ethernet/eth_arp_scan.c
@@ -1,0 +1,112 @@
+#include "sdkconfig.h"
+
+#ifdef CONFIG_WITH_ETHERNET
+
+#include "scans/ethernet/eth_arp_scan.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "lwip/etharp.h"
+#include "lwip/ip4_addr.h"
+#include <stdio.h>
+#include <string.h>
+
+bool eth_arp_build_subnet_prefix(uint32_t ip_addr, uint32_t netmask_addr,
+                                 char *prefix, size_t prefix_len) {
+    if (!prefix || prefix_len < 8) {
+        return false;
+    }
+
+    uint32_t network = ip_addr & netmask_addr;
+    snprintf(prefix, prefix_len, "%d.%d.%d.",
+             (int)((network >> 0) & 0xFF),
+             (int)((network >> 8) & 0xFF),
+             (int)((network >> 16) & 0xFF));
+    return true;
+}
+
+esp_err_t eth_arp_scan_subnet_common(eth_arp_scan_params_t *params) {
+    if (!params || !params->lwip_netif || !params->subnet_prefix ||
+        !params->hosts || params->max_hosts == 0) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    const int batch_size = 10;
+    params->found_count = 0;
+
+    if (params->progress_total <= 0) {
+        params->progress_total = ETH_ARP_SCAN_END_HOST - ETH_ARP_SCAN_START_HOST + 1;
+    }
+
+    for (int batch_start = ETH_ARP_SCAN_START_HOST;
+         batch_start <= ETH_ARP_SCAN_END_HOST;
+         batch_start += batch_size) {
+
+        if (params->cancel && *params->cancel) {
+            break;
+        }
+
+        int batch_end = batch_start + batch_size - 1;
+        if (batch_end > ETH_ARP_SCAN_END_HOST) {
+            batch_end = ETH_ARP_SCAN_END_HOST;
+        }
+
+        for (int host = batch_start; host <= batch_end; host++) {
+            if (params->cancel && *params->cancel) {
+                break;
+            }
+
+            char current_ip[26];
+            snprintf(current_ip, sizeof(current_ip), "%s%d", params->subnet_prefix, host);
+
+            ip4_addr_t target_addr;
+            if (ip4addr_aton(current_ip, &target_addr)) {
+                etharp_request(params->lwip_netif, &target_addr);
+            }
+            vTaskDelay(pdMS_TO_TICKS(10));
+        }
+
+        if (params->cancel && *params->cancel) {
+            break;
+        }
+
+        for (int i = 0; i < 5; i++) {
+            if (params->cancel && *params->cancel) {
+                break;
+            }
+            vTaskDelay(pdMS_TO_TICKS(50));
+        }
+
+        for (int host = batch_start; host <= batch_end; host++) {
+            if (params->cancel && *params->cancel) {
+                break;
+            }
+
+            char current_ip[26];
+            snprintf(current_ip, sizeof(current_ip), "%s%d", params->subnet_prefix, host);
+
+            ip4_addr_t target_addr;
+            if (!ip4addr_aton(current_ip, &target_addr)) {
+                continue;
+            }
+
+            struct eth_addr *eth_ret = NULL;
+            const ip4_addr_t *ip_ret = NULL;
+            s8_t arp_idx = etharp_find_addr(params->lwip_netif, &target_addr, &eth_ret, &ip_ret);
+
+            if (arp_idx >= 0 && eth_ret && params->found_count < params->max_hosts) {
+                arp_host_t *entry = &params->hosts[params->found_count++];
+                strlcpy(entry->ip, current_ip, sizeof(entry->ip));
+                memcpy(entry->mac, eth_ret->addr, 6);
+                entry->is_active = true;
+            }
+
+            if (params->progress_current) {
+                *params->progress_current = host - ETH_ARP_SCAN_START_HOST + 1;
+            }
+        }
+    }
+
+    return ESP_OK;
+}
+
+#endif

--- a/main/scans/wifi/arp_scan.c
+++ b/main/scans/wifi/arp_scan.c
@@ -9,8 +9,8 @@
  */
 
 #include "scans/wifi/arp_scan.h"
+#include "core/arp_scan_save.h"
 #include "core/glog.h"
-#include "core/scan_saver.h"
 #include "core/utils.h"
 #include "esp_log.h"
 #include "esp_wifi.h"
@@ -53,15 +53,12 @@ static void format_host_entry(char *buffer, size_t size, size_t index, const cha
 }
 
 /**
- * @brief Log and save a host entry
+ * @brief Log a host entry
  */
-static void log_host_entry(scan_file_t *sf, size_t index, const char *ip, const uint8_t *mac) {
+static void log_host_entry(size_t index, const char *ip, const uint8_t *mac) {
     char entry[80];
     format_host_entry(entry, sizeof(entry), index, ip, mac);
     glog("%s\n", entry);
-    if (sf && sf->fp) {
-        scan_file_printf(sf, "%s\n", entry);
-    }
 }
 
 /**
@@ -364,6 +361,12 @@ static void process_batch(arp_scanner_ctx_t *ctx, int batch_start, int batch_end
  * @brief Scan subnet for active hosts using ARP
  */
 bool arp_scan_subnet(void) {
+    return arp_scan_subnet_ex(NULL);
+}
+
+bool arp_scan_subnet_ex(const arp_scan_run_options_t *opts) {
+    const bool force_save = opts && opts->force_save;
+    const bool write_csv = opts && opts->write_csv;
     arp_scanner_ctx_t *ctx = arp_scanner_init();
     if (!ctx) {
         glog("Failed to initialize ARP scanner context\n");
@@ -401,24 +404,15 @@ bool arp_scan_subnet(void) {
         }
     }
 
-    // Open scan file for saving results
-    scan_file_t sf = SCAN_FILE_INIT;
-    bool saving = (scan_file_open(&sf, "arp_scan", "txt") == ESP_OK);
-
     // Final summary
     glog("\n=== ARP Scan Results ===\n");
     glog("Found %zu active hosts on %s0/24:\n", ctx->num_active_hosts, ctx->subnet_prefix);
-    
-    if (saving) {
-        scan_file_printf(&sf, "--- ARP Scan Results (%zu hosts) ---\n", ctx->num_active_hosts);
-        scan_file_printf(&sf, "Subnet: %s0/24\n\n", ctx->subnet_prefix);
-    }
     
     if (ctx->num_active_hosts > 0) {
         glog("\nActive hosts:\n");
         
         for (size_t i = 0; i < ctx->num_active_hosts; i++) {
-            log_host_entry(&sf, i + 1, ctx->hosts[i].ip, ctx->hosts[i].mac);
+            log_host_entry(i + 1, ctx->hosts[i].ip, ctx->hosts[i].mac);
         }
     } else {
         glog("No active hosts found.\n");
@@ -427,9 +421,27 @@ bool arp_scan_subnet(void) {
     glog("\nARP scan completed.\n");
     ESP_LOGI(TAG, "ARP scan completed. Found %zu active hosts", ctx->num_active_hosts);
 
-    if (saving) {
-        scan_file_close(&sf);
+    char scanner_ip[16] = {0};
+    esp_netif_t *sta_netif = get_wifi_sta_netif();
+    if (sta_netif) {
+        esp_netif_ip_info_t ip_info;
+        if (esp_netif_get_ip_info(sta_netif, &ip_info) == ESP_OK) {
+            esp_ip4addr_ntoa(&ip_info.ip, scanner_ip, sizeof(scanner_ip));
+        }
     }
+
+    char saved_path[128];
+    arp_scan_save_input_t save_in = {
+        .subnet_prefix = ctx->subnet_prefix,
+        .iface = ARP_SCAN_IFACE_WIFI,
+        .scanner_ip = scanner_ip[0] ? scanner_ip : NULL,
+        .hosts = ctx->hosts,
+        .host_count = ctx->num_active_hosts,
+        .force_save = force_save,
+        .write_csv = write_csv,
+    };
+    esp_err_t save_err = arp_scan_save_results(&save_in, saved_path, sizeof(saved_path));
+    arp_scan_save_report_status(save_err, saved_path[0] ? saved_path : NULL);
 
     arp_scanner_cleanup(ctx);
     return true;


### PR DESCRIPTION
Add shared arp_scan_save helper gated by auto_save_scans with -s/--csv overrides. Wire WiFi scanarp, etharp CLI, async Ethernet UI scans, and ARP poison host discovery. Consolidate Ethernet ARP scan logic, enrich saved files with timestamp and OUI vendor, and document filename patterns in sd-card.md.

I've tested this on my RL Phantom and it performs as expected.

Fixes ISSUE #247 