### PR TITLE
fix(lvgl): use IDF 6.x LEDC sig_out_idx field in backlight driver

### DIFF
--- a/components/lvgl_esp32_drivers/lvgl_tft/esp_lcd_backlight.c
+++ b/components/lvgl_esp32_drivers/lvgl_tft/esp_lcd_backlight.c
@@ -68,7 +68,7 @@ disp_backlight_h disp_backlight_new(const disp_backlight_config_t *config)
         ESP_ERROR_CHECK(ledc_timer_config(&LCD_backlight_timer));
         ESP_ERROR_CHECK(ledc_channel_config(&LCD_backlight_channel));
 #if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 0, 0)
-        gpio_matrix_output(config->gpio_num, ledc_periph_signal[LEDC_LOW_SPEED_MODE].sig_out0_idx + config->channel_idx, config->output_invert, 0);
+        gpio_matrix_output(config->gpio_num, ledc_periph_signal[0].speed_mode[LEDC_LOW_SPEED_MODE].sig_out_idx[config->channel_idx], config->output_invert, 0);
 #else
         gpio_iomux_out(config->gpio_num, ledc_periph_signal[LEDC_LOW_SPEED_MODE].sig_out0_idx + config->channel_idx, config->output_invert);
 #endif


### PR DESCRIPTION
## Problem
On the IDF 6.x build path, `disp_backlight_new()` in `components/lvgl_esp32_drivers/lvgl_tft/esp_lcd_backlight.c` switched to `gpio_matrix_output()` but still referenced the old ESP-IDF 5.x `ledc_signal_conn_t` field:

```c
ledc_periph_signal[LEDC_LOW_SPEED_MODE].sig_out0_idx + config->channel_idx
```

That field no longer exists in ESP-IDF 6.x — the struct was redesigned to:

```c
ledc_periph_signal[group].speed_mode[mode].sig_out_idx[channel]
```

so the LCD backlight driver fails to compile under IDF 6.x:

```
error: 'ledc_signal_conn_t' has no member named 'sig_out0_idx'
```

This was the only blocker preventing a clean CYD2432S028R build against IDF 6.x.

## Fix
Update the `ESP_IDF_VERSION >= 6.0.0` branch to use the new field access, matching the official `esp_driver_ledc/src/ledc.c` usage. The pre-6.0 (`#else`) path is unchanged.

## Testing
Built the CYD2432S028R target against ESP-IDF 6.x; the backlight driver now compiles where it previously failed at this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)