### PR TITLE
Fix Cardputer S3 boot crash and SD Init stack overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## Attribution
 Untagged entries are by ([@jaylikesbunda](https://github.com/jaylikesbunda)). A trailing `@handle` credits a guest contributor for that specific line. "Ported from / adapted from" credits the upstream source a feature was based on, not GhostESP authorship.
 
+## Revival v2.1.3
+
+### Bug Fixes
+- Fixed boot crash on Cardputer (and other M5GFX boards) under ESP-IDF 6.1 by resetting the new spi_bus_config_t.dma_burst_size field to the driver default after M5GFX fills the config with 0xFF
+- Raised the SD Init task stack from 6K to 8K, fixing a boot-time stack overflow on Cardputer ADV
+
 ## Revival v2.1.2
 
 ### Added

--- a/components/M5GFX/src/lgfx/v1/platforms/esp32/common.cpp
+++ b/components/M5GFX/src/lgfx/v1/platforms/esp32/common.cpp
@@ -628,6 +628,12 @@ namespace lgfx
         buscfg.isr_cpu_id = INTR_CPU_ID_AUTO;
   #endif
 #endif
+#if defined (ESP_IDF_VERSION_VAL) && (ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(6, 1, 0))
+        // IDF 6.1 added dma_burst_size to spi_bus_config_t; the struct was
+        // memset to ~0 above, so reset it to 0 (driver default) to avoid
+        // gdma_config_transfer rejecting an invalid burst size.
+        buscfg.dma_burst_size = 0;
+#endif
         if (ESP_OK != spi_bus_initialize(static_cast<spi_host_device_t>(spi_host), &buscfg, dma_channel))
         {
           ESP_LOGW("LGFX", "Failed to spi_bus_initialize. ");

--- a/include/core/ghostesp_version.h
+++ b/include/core/ghostesp_version.h
@@ -3,7 +3,7 @@
 
 #define GHOSTESP_NAME "GhostESP"
 #define GHOSTESP_FLAVOR "Revival"
-#define GHOSTESP_VERSION "v2.1.2"
+#define GHOSTESP_VERSION "v2.1.3"
 
 // GIT_COMMIT_HASH and GIT_BRANCH are defined as compile definitions in CMakeLists.txt
 

--- a/main/main.c
+++ b/main/main.c
@@ -1132,7 +1132,9 @@ void app_main(void) {
     // handled by the separate boot_app_discovery_task spawned from inside
     // deferred_sd_init_task.
     {
-        BaseType_t sd_task_rc = xTaskCreate(deferred_sd_init_task, "SD Init", 6144, NULL,
+        // 8K: sd_card_init's SDMMC/SPI locals + coredump autosave + asset pack
+        // load are all sequential in this task; 6K overflowed on Cardputer ADV.
+        BaseType_t sd_task_rc = xTaskCreate(deferred_sd_init_task, "SD Init", 8192, NULL,
                                             tskIDLE_PRIORITY + 1, NULL);
         if (sd_task_rc != pdPASS) {
             ESP_LOGE(TAG, "Failed to create SD Init task");


### PR DESCRIPTION
- M5GFX: reset spi_bus_config_t dma_burst_size to 0 (driver default) on ESP-IDF 6.1+, fixing gdma reject + boot panic on SPI display init

- main: raise SD Init task stack 6K to 8K (boot-time overflow on Cardputer ADV)

- CHANGELOG: add Revival v2.1.3 bug-fix section

# What's new (Author - fill this out)
- 

# Changed
-

# Removed
-

# Verification (Author - fill this out)
- I have tested Primary device(s) (list exact HW + config): 
- I have tested potentially affected devices (and/or list potential affected devices not available to you):  
- I have wrapped device specific code with `#ifdef CONFIG_...` or similar: [ ] Yes / [ ] N/A
- I have updated Hugo Docs with any new or changed info for end users: [ ] Yes / [ ] N/A

## Linked Issues
- Closes #

## Checklist (Reviewer - don't fill this out)
- [ ] Code builds, flashes, and feature verified with no functional issues on listed device(s)
- [ ] Changes reviewed for unintended impact on other devices/targets

