### PR TITLE
Add ESPNOW permission and update SD mount API

### DIFF
--- a/main/managers/plugin_api.c
+++ b/main/managers/plugin_api.c
@@ -325,6 +325,7 @@ static plugin_permission_t plugin_api_permission_from_string(const char *value) 
     if (strcmp(value, "settings") == 0) return PLUGIN_PERMISSION_SETTINGS;
     if (strcmp(value, "zigbee") == 0 || strcmp(value, "ieee802154") == 0) return PLUGIN_PERMISSION_ZIGBEE;
     if (strcmp(value, "nrf24") == 0) return PLUGIN_PERMISSION_NRF24;
+    if (strcmp(value, "espnow") == 0 || strcmp(value, "esp_now") == 0) return PLUGIN_PERMISSION_ESPNOW;
     return 0;
 }
 

--- a/main/managers/sd_card_manager.c
+++ b/main/managers/sd_card_manager.c
@@ -1602,13 +1602,8 @@ esp_err_t sd_card_resume_from_usb_msc(void) {
    * this recreates the mount from scratch without re-probing the card. */
   ff_diskio_register_sdmmc(pdrv, card);
   char drv[3] = {(char)('0' + pdrv), ':', 0};
-  esp_vfs_fat_conf_t conf = {
-      .base_path = SD_MOUNT_POINT,
-      .fat_drive = drv,
-      .max_files = 3,
-  };
   FATFS *fs = NULL;
-  esp_err_t err = esp_vfs_fat_register(&conf, &fs);
+  esp_err_t err = esp_vfs_fat_register(SD_MOUNT_POINT, drv, 3, &fs);
   if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
     ESP_LOGE(TAG, "USB MSC resume: VFS register failed: %s", esp_err_to_name(err));
     ff_diskio_unregister(pdrv);

--- a/plugins/package.schema.json
+++ b/plugins/package.schema.json
@@ -29,6 +29,7 @@
           "command",
           "tasks",
           "wifi",
+          "espnow",
           "ble",
           "nfc",
           "ir",


### PR DESCRIPTION
Recognize "espnow"/"esp_now" in plugin permission parsing and add "espnow" to plugins schema so plugins can request ESPNOW access. Update sd_card_manager resume path to use the esp_vfs_fat_register(path, drive, max_files, &fs) overload instead of building an esp_vfs_fat_conf_t, ensuring correct FAT VFS re-registration during USB MSC resume. Error handling and logging unchanged.

# What's new (Author - fill this out)
- Added espnow/esp_now plugin permission parsing.
- Added espnow to the plugin permission schema.
- Updated SD-card VFS re-registration during USB MSC resume.

# Changed
- SD resume now uses esp_vfs_fat_register() with explicit path, drive, and file-limit arguments.
- Existing error handling and logging are unchanged.

# Removed
- Removed temporary esp_vfs_fat_conf_t construction from the resume path.

# Verification (Author - fill this out)
- I have tested Primary device(s) (list exact HW + config): Banshee somethingsomething
- I have tested potentially affected devices (and/or list potential affected devices not available to you):  ESP32-S3 USB MSC/SD configurations and plugin-enabled targets require hardware validation.
- I have wrapped device specific code with `#ifdef CONFIG_...` or similar: [ ] Yes / [ x] N/A
- I have updated Hugo Docs with any new or changed info for end users: [ ] Yes / [ x] N/A

## Linked Issues
- Closes #

## Checklist (Reviewer - don't fill this out)
- [ ] Code builds, flashes, and feature verified with no functional issues on listed device(s)
- [ ] Changes reviewed for unintended impact on other devices/targets

