### PR TITLE
Add espnow support to plugin permissions

### DIFF
--- a/main/managers/plugin_api.c
+++ b/main/managers/plugin_api.c
@@ -325,6 +325,7 @@ static plugin_permission_t plugin_api_permission_from_string(const char *value) 
     if (strcmp(value, "settings") == 0) return PLUGIN_PERMISSION_SETTINGS;
     if (strcmp(value, "zigbee") == 0 || strcmp(value, "ieee802154") == 0) return PLUGIN_PERMISSION_ZIGBEE;
     if (strcmp(value, "nrf24") == 0) return PLUGIN_PERMISSION_NRF24;
+    if (strcmp(value, "espnow") == 0 || strcmp(value, "esp_now") == 0) return PLUGIN_PERMISSION_ESPNOW;
     return 0;
 }
 

--- a/plugins/package.schema.json
+++ b/plugins/package.schema.json
@@ -29,6 +29,7 @@
           "command",
           "tasks",
           "wifi",
+          "espnow",
           "ble",
           "nfc",
           "ir",


### PR DESCRIPTION
This adds the espnow / esp_now permission string to the plugin API permission parser and includes it in the plugin package schema enum so plugins can declare the capability correctly.

# What's new (Author - fill this out)
- Native plugins can declare ESP-NOW permission correctly.

# Changed
- Added ESP-NOW permission parsing in main/managers/plugin_api.c.
- Added espnow to plugins/package.schema.json.

# Removed
- None.

# Verification (Author - fill this out)
- Build verified for Banshee C5 / ESP32-C5 using configs/sdkconfig.somethingsomething and ESP-IDF v6.1.
- Banshee boots as normal / radar app works
- Potentially affected: all GhostESP targets loading native SD plugins.
- I have wrapped device specific code with `#ifdef CONFIG_...` or similar: [ ] Yes / [ x] N/A
- I have updated Hugo Docs with any new or changed info for end users: [ ] Yes / [ x] N/A

## Linked Issues
- Closes #

## Checklist (Reviewer - don't fill this out)
- [ ] Code builds, flashes, and feature verified with no functional issues on listed device(s)
- [ ] Changes reviewed for unintended impact on other devices/targets

